### PR TITLE
Added root-url param to redirect to there after login

### DIFF
--- a/dcos-oauth/flags.go
+++ b/dcos-oauth/flags.go
@@ -55,6 +55,11 @@ var (
 		Usage: "oauth-callback-url",
 		Value: "https://oauth-callback-url",
 	}
+	flRootUrl = cli.StringFlag{
+		Name: "root-url",
+		Usage: "root-url",
+		Value: "https://root-url",
+	}
 	flOauthProfileUrl = cli.StringFlag{
 		Name: "oauth-profile-url",
 		Usage: "profile url",

--- a/dcos-oauth/login.go
+++ b/dcos-oauth/login.go
@@ -168,7 +168,8 @@ func handleLogin(ctx context.Context, w http.ResponseWriter, r *http.Request) *c
 
 	http.SetCookie(w, infoCookie)
 
-	http.Redirect(w, r, "https://"+r.Host, http.StatusFound)
+	rootUrl := ctx.Value("root-url").(string)
+	http.Redirect(w, r, rootUrl, http.StatusFound)
 
 	return nil
 }

--- a/dcos-oauth/main.go
+++ b/dcos-oauth/main.go
@@ -16,7 +16,7 @@ func main() {
 		Usage:     "Serve the API",
 		Flags:     []cli.Flag{common.FlAddr, flIssuerURL, flClientID, flSecretKeyPath,
 		flSegmentKey, flOauthAppKey, flOauthAppSecret, flOauthTokenUrl, flOauthAuthUrl,
-		flOauthProfileUrl,flOauthCallbackUrl,flAuthorizedRole,flDomain,flPath},
+		flRootUrl, flOauthProfileUrl,flOauthCallbackUrl,flAuthorizedRole,flDomain,flPath},
 		Action:    action(serveAction),
 	}
 
@@ -36,6 +36,7 @@ func serveAction(c *cli.Context) error {
 	ctx = context.WithValue(ctx, "oauth-callback-url", c.String("oauth-callback-url"))
 	ctx = context.WithValue(ctx, "oauth-profile-url", c.String("oauth-profile-url"))
 	ctx = context.WithValue(ctx, "authorized-role", c.String("authorized-role"))
+	ctx = context.WithValue(ctx, "root-url", c.String("root-url"))
 	ctx = context.WithValue(ctx, "domain", c.String("domain"))
 	ctx = context.WithValue(ctx, "path", c.String("path"))
 


### PR DESCRIPTION
Redirect to root-url url (server+path) after login (instead of redirecting to / directly).

Needed to work with vpath proxy with adminrouter located somewhere different to / (https://stratio.atlassian.net/browse/EOS-522).

This change is already packed in Stratio EOS 0.11-X